### PR TITLE
Fix curl|python3 stdin hang; clarify install & SIP behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,26 @@ Interactive console util to disable 269 non-essential macOS launchd services. Re
 
 **No SIP disable required** — works with System Integrity Protection fully on, via Apple's supported `launchctl disable`. That covers ~90-95% of the bloat with zero security tradeoff; squeezing the last few daemons means turning SIP off permanently, which isn't worth it for most people. It also validates every service against your actual system at launch, so it never acts on a label that doesn't exist on your macOS build.
 
+## Requirements
+
+- macOS Tahoe 26.x, Apple Silicon
+- Python 3.10+ — ships with Xcode Command Line Tools. If `python3` isn't
+  found, run `xcode-select --install` first (macOS will prompt with a GUI
+  installer on first launch).
+- No SIP disable required for the default label set.
+
 ```bash
 npx -y @oleksandr_krupko/mac-os-debloat
 ```
 
-Or via curl:
+Or via curl — download it first, then run it (see
+[Troubleshooting](#troubleshooting) for why not to pipe straight into
+`python3`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OleksandrKrupko/mac-os-debloat/main/debloat | python3
+curl -fsSL https://raw.githubusercontent.com/OleksandrKrupko/mac-os-debloat/main/debloat -o debloat
+chmod +x debloat
+python3 debloat
 ```
 
 Or via Homebrew:
@@ -124,6 +136,31 @@ Uses `launchctl disable` — writes to `/var/db/com.apple.xpc.launchd/disabled.p
 - Wiped by macOS major upgrades (26.3 → 26.4 etc) — re-run after upgrade
 - `system/` disables affect all users · `gui/$UID` disables only current user
 - Multi-user: run once per account
+
+</details>
+
+<a id="troubleshooting"></a>
+<details>
+<summary><b>Troubleshooting</b></summary>
+
+**`curl ... | python3` hangs, spins, or keys don't respond**
+Piping directly into `python3` sends the script's own source over stdin, so
+by the time the TUI starts, stdin is no longer attached to your keyboard —
+the input loop free-spins and repeatedly calls `mdutil` for the status line,
+pegging a CPU core. Download the script to a file and run the file instead
+(see install instructions above). v0.5.1+ detects this and exits with a
+clear message instead of hanging.
+
+**`Boot-out failed: 150: Operation not permitted while SIP is engaged`**
+(e.g. on `com.apple.followupd`)
+Expected for a handful of daemons Apple protects even from a live
+`bootout`. This is *not* something you need to disable SIP to fix:
+`launchctl disable` — the persistent, SIP-safe half of the operation —
+already succeeded and takes effect on your next login/reboot. The failed
+`bootout` only means that one process couldn't be killed *immediately*; run
+`debloat --status` after a reboot to confirm it's disabled. Disabling SIP
+permanently isn't necessary and isn't recommended by this project — see the
+comparison table below.
 
 </details>
 

--- a/debloat
+++ b/debloat
@@ -1030,7 +1030,7 @@ def load_sections() -> tuple[list[Section], str, list[str]]:
     return sections, note, absent
 
 
-VERSION = "0.5.0"
+VERSION = "0.5.1"
 
 HELP = f"""mac-os-debloat {VERSION} — toggle non-essential macOS launchd services.
 
@@ -1091,6 +1091,21 @@ def main() -> int:
     if absent:
         print(f"skipped {len(absent)} labels not present on this macOS build "
               f"(see `debloat --audit`)")
+
+    if not sys.stdin.isatty():
+        print(
+            "error: stdin isn't a terminal, so the interactive TUI can't "
+            "read keypresses. This usually means the script was run via "
+            "`curl ... | python3`.\n\n"
+            "Download it first, then run the file directly:\n\n"
+            "  curl -fsSL https://raw.githubusercontent.com/OleksandrKrupko/"
+            "mac-os-debloat/main/debloat -o debloat\n"
+            "  chmod +x debloat\n"
+            "  python3 debloat\n",
+            file=sys.stderr,
+        )
+        return 1
+
     refresh_state(sections)
     result = curses.wrapper(run_tui, sections)
     if result:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oleksandr_krupko/mac-os-debloat",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Debloat your Mac from the terminal. SIP-safe interactive console util to disable 269 non-essential macOS launchd services + Spotlight toggle. Self-validates against your macOS build. macOS Tahoe + Apple Silicon. Zero deps.",
   "bin": {
     "mac-os-debloat": "bin/cli.js",


### PR DESCRIPTION
Closes #1

## Summary
Fixes the hang/freeze reported when installing via
`curl -fsSL ... | python3`, and documents the (expected, non-fatal)
`Boot-out failed: 150 ... SIP is engaged` message some users see on a
handful of protected daemons like `com.apple.followupd`.

## Root cause analysis

**The hang:** `curl | python3` passes no filename to the interpreter, so
Python reads its own source *from stdin* to build the script, then executes
it. By the time `curses.wrapper(run_tui, sections)` starts, fd 0 is already
at EOF — it's no longer connected to the terminal's keyboard. curses'
`getch()` therefore doesn't block waiting for real input the way it does in
a normal interactive session; the input loop free-spins.

Each spin calls `draw()`, which renders the status line via
`spotlight_status_line() → spotlight_state()`, and that function shells out
to `mdutil -s /System/Volumes/Data` on every call. With the loop no longer
blocked on real keystrokes, this becomes hundreds/thousands of `mdutil`
subprocess spawns per second — which is the "loop" reported in #1, and
enough to peg a core and make the terminal appear frozen. Keypresses aren't
being mishandled; they never reach `getch()`, because fd 0 isn't the
keyboard anymore.

This only affects the pipe-to-interpreter install path. `npx` and
`brew install` both write the script to a real file first and invoke
`python3 /path/to/debloat`, so fd 0 stays attached to the terminal — no
regression there, and no change needed to those paths.

**Fix:** added an `if not sys.stdin.isatty()` guard immediately before the
`curses.wrapper(...)` call in `main()` — and *only* there, so the existing
non-interactive flags (`--status`, `--audit`, `--restore`, `--dry-run`,
`--enable-all`, `--disable-all`) are untouched and keep working when piped
(e.g. `debloat --status --json | jq`). On non-TTY stdin, it now prints an
actionable error pointing at the corrected install command and exits 1,
instead of spinning.

**The SIP message:** `com.apple.followupd` (and a few similar daemons) are
protected by SIP against live `bootout`, even though `launchctl disable` —
the persistent, SIP-safe mechanism this tool relies on for everything — is
explicitly allowed and still succeeds. `apply_changes()` already runs that
subprocess with `check=False`, so this was never fatal; it just wasn't
documented. I did **not** add a "disable SIP" requirement, since that
contradicts the project's core design and its comparison-table claim over
the b0gdanw gist ("No SIP disable" ✓ vs "needs SIP off" ✗). Documented it
as expected behavior in a new Troubleshooting section instead — the pending
`launchctl disable` still takes effect on next reboot regardless of the
`bootout` failure.

## Changes
- `debloat`: stdin/TTY guard before the TUI entrypoint; version bump to
  0.5.1.
- `README.md`: new `## Requirements` section (macOS/Python CLT
  prerequisites, per #1's request), corrected curl install instructions
  (download-then-run), new Troubleshooting section covering both symptoms
  from #1.
- `package.json`: version bump to 0.5.1, matching how previous releases
  bumped both files together.

## Testing performed
- Hit the original hang myself with `curl ... | python3` on macOS Tahoe
  (unresponsive TUI, exactly as described in #1) before the fix.
- Verified the guard with a test harness simulating non-TTY stdin (curses
  and the `launchctl`/`sw_vers`/`mdutil` calls stubbed): the TUI path now
  exits 1 with the new message *before* any `curses` call, and `--version`
  / `--status` still work with stdin piped — they return before reaching
  the guard.
- `python3 -m py_compile debloat` passes.
