### PR TITLE
docs: Troubleshooting entry for SIP "Boot-out failed: 150" message

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Uses `launchctl disable` — writes to `/var/db/com.apple.xpc.launchd/disabled.p
 </details>
 
 <details>
+<summary><b>Troubleshooting</b></summary>
+
+**`Boot-out failed: 150: Operation not permitted while System Integrity Protection is engaged`** (e.g. on `com.apple.followupd`)
+Expected for a handful of daemons Apple protects even from a live `bootout`, and not a reason to disable SIP. The persistent half — `launchctl disable` — already succeeded and takes effect on your next login/reboot; the failed `bootout` only means that one running process couldn't be killed immediately. Run `debloat --status` after a reboot to confirm it's disabled.
+
+</details>
+
+<details>
 <summary><b>Customizing</b></summary>
 
 Drop a `labels.txt` next to the script — it overrides embedded list.


### PR DESCRIPTION
Adds a Troubleshooting section to the README documenting the `Boot-out failed: 150: Operation not permitted while System Integrity Protection is engaged` message (seen on daemons like `com.apple.followupd`): it's expected, harmless, and not a reason to disable SIP — `launchctl disable` already succeeded and persists across reboot.

Credit to @k0shir0 — picked from #3. The stdin-hang fix from that PR was superseded by v0.5.1 (19b02e0), which reopens `/dev/tty` so the `curl | python3` one-liner keeps working interactively instead of erroring out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)