### PR TITLE
feat: disable com.apple.accessibility.axassetsd (270 labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Debloat your Mac from the terminal. Zero dependencies. Zero install.**
 
-Interactive console util to disable 269 non-essential macOS launchd services. Reclaims ~1.5-2 GB RAM and a chunk of CPU for whatever heavy work you're actually doing. Persistent across reboot. Fully reversible. Built for macOS Tahoe 26.x on Apple Silicon.
+Interactive console util to disable 270 non-essential macOS launchd services. Reclaims ~1.5-2 GB RAM and a chunk of CPU for whatever heavy work you're actually doing. Persistent across reboot. Fully reversible. Built for macOS Tahoe 26.x on Apple Silicon.
 
 **No SIP disable required** — works with System Integrity Protection fully on, via Apple's supported `launchctl disable`. That covers ~90-95% of the bloat with zero security tradeoff; squeezing the last few daemons means turning SIP off permanently, which isn't worth it for most people. It also validates every service against your actual system at launch, so it never acts on a label that doesn't exist on your macOS build.
 
@@ -71,7 +71,7 @@ pending: 4   (spotlight: ON)   (checked = enabled/running)
 <details>
 <summary><b>What it disables</b></summary>
 
-269 labels across 69 sections. Highlights:
+270 labels across 69 sections. Highlights:
 
 - Siri / voice assistant (12)
 - Apple Intelligence — Tahoe (10), incl. `contextstored` (known >30 GB memory leak) and `privatecloudcomputed`
@@ -180,7 +180,7 @@ The ~1.5-2 GB figure is the drop in used memory on an idle M4 MacBook Pro 16 GB 
 
 | Tool | Console UI | Curated list | Persistent | No SIP disable | Zero install |
 |------|-----------|--------------|------------|----------------|--------------|
-| **mac-os-debloat** | ✓ | ✓ 269 labels | ✓ | ✓ | ✓ Python stdlib |
+| **mac-os-debloat** | ✓ | ✓ 270 labels | ✓ | ✓ | ✓ Python stdlib |
 | [launchtui](https://github.com/macournoyer/launchtui) | ✓ | ✗ generic | ✗ bootout only | ✓ | ✗ `cargo install` |
 | [Silverback-Debloater](https://github.com/Wamphyre/macOS_Silverback-Debloater) | ✗ | ✓ | ✓ | ✓ | ✗ Intel-desktop only |
 | [b0gdanw Tahoe gist](https://gist.github.com/b0gdanw/0c20c2fd5d0a7e6cff01849b57108967) | ✗ | ✓ | ✓ | ✗ needs SIP off | gist copy |

--- a/debloat
+++ b/debloat
@@ -382,6 +382,7 @@ com.apple.translationd                        # Apple Translate API (Translate a
 com.apple.notes.exchangenotesd                # Apple Notes Exchange sync
 com.apple.VoiceOver                           # screen reader (no accessibility use)
 com.apple.accessibility.LiveTranscriptionAgent  # live transcription/captions
+com.apple.accessibility.axassetsd              # TTS voice + VoiceOver/Magnifier model asset downloads
 com.apple.DictationIM                         # dictation input method
 com.apple.voicebankingd                       # custom voice creation (Live Speech)
 com.apple.voicememod                          # Voice Memos app
@@ -1046,7 +1047,7 @@ def load_sections() -> tuple[list[Section], str, list[str]]:
     return sections, note, absent
 
 
-VERSION = "0.5.1"
+VERSION = "0.5.2"
 
 HELP = f"""mac-os-debloat {VERSION} — toggle non-essential macOS launchd services.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oleksandr_krupko/mac-os-debloat",
-  "version": "0.5.1",
-  "description": "Debloat your Mac from the terminal. SIP-safe interactive console util to disable 269 non-essential macOS launchd services + Spotlight toggle. Self-validates against your macOS build. macOS Tahoe + Apple Silicon. Zero deps.",
+  "version": "0.5.2",
+  "description": "Debloat your Mac from the terminal. SIP-safe interactive console util to disable 270 non-essential macOS launchd services + Spotlight toggle. Self-validates against your macOS build. macOS Tahoe + Apple Silicon. Zero deps.",
   "bin": {
     "mac-os-debloat": "bin/cli.js",
     "debloat": "bin/cli.js"


### PR DESCRIPTION
Adds `com.apple.accessibility.axassetsd` to the curated list — the one genuinely new label from #5. The other suggestion in that issue, `com.apple.corespeechd`, has been in the list since before (`debloat:201`, along with `com.apple.corespeechd_system`).

## Why it belongs

Everything it does is Siri-TTS / accessibility asset work, per its own plist:

- **On-demand:** `MobileAsset.UAF.Siri.TextToSpeech`, `VoiceServices.GryphonVoice`, `VoiceServices.CustomVoice` new-asset-installed notifications, `SynthesisProvider.updatedVoices`, `ttsasset.NewAssetNotification`
- **Periodic XPC activities:** `ImageCaptionModel` (24h), `AXIconVision` (72h), `MagnifierAsset` (72h)

It links `TextToSpeech`, `SiriTTSService` (weak), `TextToSpeechVoiceBankingSupport`, `AXCoreUtilities`, `AccessibilityUtilities`. Every consumer-side daemon for those is already in the list: `sirittsd`, `SiriTTSTrainingAgent`, `speech.speechsynthesisd.arm64`, `speech.speechdatainstallerd`, `voicebankingd`, `VoiceOver`, `accessibility.LiveTranscriptionAgent`. So for anyone who takes those, this is the leftover downloader with nothing left to feed.

Placed in the accessibility section so it inherits the existing "no accessibility use" caveat rather than reading as a free win. Real cost if you *do* use VoiceOver / Spoken Content / Magnifier / Live Speech: stale or missing voice + caption model assets.

It's a user LaunchAgent (`/System/Library/LaunchAgents/com.apple.accessibility.axassetsd.plist`), so plain SIP-safe `launchctl disable gui/$UID`, reversible by unchecking.

## Verification

```
$ ./debloat --audit     # before
267 labels present on this macOS build.
$ ./debloat --audit     # after
268 labels present on this macOS build.
```

`enabled` went 20 → 21 in `--status --json`, i.e. the label resolves against live launchd and is not a phantom. `KeepAlive=false` / `ProcessType=Adaptive`, so the win is the periodic wakeups, not a resident process — not overstated in the changelog.

Not tested: whether Spoken Content still enumerates/downloads voices with it disabled. Doesn't block the label, since it's opt-in and reversible.

## Sync

0.5.1 → 0.5.2, count 269 → 270 in `debloat` VERSION, `package.json` (version + description), README (intro, "What it disables", comparison table). Section count stays 69.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)