### PR TITLE
fix: take running pids from launchd, surface overrides it ignores (0.7.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ debloat                    # interactive TUI (default)
 debloat --preset telemetry # disable analytics, crash reports, ads, beta enrollment (46)
 debloat --preset balanced  # telemetry + Siri, Apple Intelligence, iMessage, Family (172)
 debloat --list             # print every label, in preset file format
-debloat --status           # per-domain disabled/enabled counts, how many are running, spotlight, free RAM
+debloat --status           # per-domain disabled/enabled, how many run, how many ignore the override, free RAM
 debloat --audit            # list any embedded labels not present on your macOS build
 debloat --disable-all      # disable every label, no exceptions (prompts sudo)
 debloat --enable-all       # re-enable everything — the panic button
@@ -150,9 +150,14 @@ Uses `launchctl disable`, which writes an override table per launchd domain: `sy
 - `system/` disables affect all users · `gui/$UID` disables only current user
 - Multi-user: run once per account
 
-**Reboot persistence is not guaranteed on macOS 26.x.** Measured on 26.5.2 (25F84) with SIP enabled: after a boot, 264 of the 268 catalog labels had no override in effect in the domain their job runs in, and 104 of them were running. `disabled.plist` held 258 overrides, `disabled.$UID.plist` only 95, and both files had been rewritten one minute after boot. The write itself is fine — `sudo launchctl disable gui/$UID/<agent>` returns 0 and the key appears in `disabled.$UID.plist` immediately — so the overrides are lost after the apply, not during it. The mechanism is not established. Reported in [#8](https://github.com/OleksandrKrupko/mac-os-debloat/issues/8).
+**macOS 26.x does not reliably honour these overrides.** Two separate failures, both measured on 26.5.2 (25F84) with SIP enabled:
 
-So don't trust it, check it: `debloat --status` reports the per-domain truth plus how many of the labels are running right now. If that count is non-zero after a reboot, re-apply. Every apply also verifies itself and prints any label whose override did not take effect, rather than reporting success.
+- **Overrides are cleared at boot, selectively.** After a boot, 264 of the 268 catalog labels had no override in effect in the domain their job runs in. The ones that get cleared are the ones that would have taken effect; overrides sitting in a domain where the job isn't registered survive untouched. Both store files are rewritten within two minutes of boot. The write itself is fine — `sudo launchctl disable gui/$UID/<agent>` returns 0 and the key appears immediately — so they are lost after the apply, not during it. Reported in [#8](https://github.com/OleksandrKrupko/mac-os-debloat/issues/8).
+- **launchd also starts jobs whose override is intact.** On a machine 8 days into an uptime, 14 catalog labels were disabled in every domain they are registered in and running anyway, started by launchd (`ppid 1`) up to 19 hours after the override store was last written. `launchctl print-disabled system` reads `=> disabled` for them the whole time.
+
+Neither mechanism is established, and no version of this tool can fix either from userspace — `launchctl disable` is the supported SIP-safe interface, and it is what is being ignored.
+
+So don't trust it, check it. `debloat --status` reports the per-domain truth, how many catalog services are running right now, and how many of them are **disabled but running anyway** — that last number is the one that catches both failures. If it's non-zero, the overrides are not being honoured on your build. Every apply also verifies itself and prints any label whose override did not take effect, rather than reporting success.
 
 </details>
 

--- a/debloat
+++ b/debloat
@@ -526,13 +526,14 @@ def plist_domains() -> dict[str, set[str]]:
     return found
 
 
-def domain_state(domain: str) -> tuple[set[str], set[str]]:
-    """(labels registered in the domain, labels disabled by an override there).
+def domain_state(domain: str) -> tuple[dict[str, int], set[str]]:
+    """({label: pid, 0 when not running}, labels disabled by an override there).
     One `launchctl print <domain>` carries both; its `disabled services` block
-    is the same table `print-disabled` shows."""
+    is the same table `print-disabled` shows, and its `services` block is
+    launchd's own pid for every job registered in the domain."""
     r = subprocess.run(["launchctl", "print", domain],
                        capture_output=True, text=True, check=False)
-    registered: set[str] = set()
+    registered: dict[str, int] = {}
     disabled: set[str] = set()
     block = ""
     for line in r.stdout.splitlines():
@@ -546,7 +547,7 @@ def domain_state(domain: str) -> tuple[set[str], set[str]]:
         if block == "services":
             fields = line.split()
             if fields:
-                registered.add(fields[-1])
+                registered[fields[-1]] = int(fields[0]) if fields[0].isdigit() else 0
         elif block == "disabled services":
             entry = re.match(r'\s*"([^"]+)"\s*=>\s*(true|disabled)\s*$', line)
             if entry:
@@ -587,36 +588,18 @@ def refresh_state(sections: list[Section]) -> None:
             it.selected = not it.disabled
 
 
-def find_pids_for_labels(labels: list[str]) -> dict[str, list[int]]:
-    """Return {label: [pids]} for labels with matching running processes.
-    Matches by basename of executable equal to label's last segment,
-    or by label appearing in full command line."""
+def running_pids(labels: list[str]) -> dict[str, list[int]]:
+    """{label: [pids]} for the given labels, straight from launchd. Matching a
+    process name to a label instead guesses wrong whenever two labels share a
+    last segment (`com.apple.spindump` / `com.apple.metadata.mds.spindump`)."""
     if not labels:
         return {}
-    r = subprocess.run(["ps", "-axm", "-o", "pid=,comm="],
-                       capture_output=True, text=True, check=False)
-    short_to_label: dict[str, str] = {}
-    for lab in labels:
-        short_to_label[lab.rsplit(".", 1)[-1]] = lab
-    label_set = set(labels)
+    wanted = set(labels)
     out: dict[str, list[int]] = {}
-    for line in r.stdout.splitlines():
-        parts = line.strip().split(None, 1)
-        if len(parts) < 2:
-            continue
-        pid_str, cmd = parts
-        try:
-            pid = int(pid_str)
-        except ValueError:
-            continue
-        cmd_short = cmd.rsplit("/", 1)[-1]
-        if cmd_short in short_to_label:
-            out.setdefault(short_to_label[cmd_short], []).append(pid)
-            continue
-        for lab in label_set:
-            if lab in cmd:
-                out.setdefault(lab, []).append(pid)
-                break
+    for domain in DOMAINS:
+        for label, pid in domain_state(domain)[0].items():
+            if pid and label in wanted:
+                out.setdefault(label, []).append(pid)
     return out
 
 
@@ -665,7 +648,7 @@ def apply_changes(sections: list[Section]) -> dict:
     # Phase 2: nuclear kill -9 for anything still running after bootout
     killed = 0
     if to_disable:
-        survivors = find_pids_for_labels(to_disable)
+        survivors = running_pids(to_disable)
         for label, pids in survivors.items():
             for pid in pids:
                 r = subprocess.run(["sudo", "kill", "-9", str(pid)],
@@ -677,7 +660,7 @@ def apply_changes(sections: list[Section]) -> dict:
     time.sleep(0.4)
     stragglers: dict[str, list[int]] = {}
     if to_disable:
-        stragglers = find_pids_for_labels(to_disable)
+        stragglers = running_pids(to_disable)
 
     disabled_now = {d: domain_state(d)[1] for d in DOMAINS}
     return {
@@ -944,11 +927,7 @@ def run_tui(stdscr, sections: list[Section]) -> str | None:
         elif c == ord("["):
             cursor = jump_section(sections, flat, cursor, direction=-1)
         elif c == ord("r"):
-            curses.endwin()
-            if not prime_sudo():
-                return "sudo failed"
             refresh_state(sections)
-            stdscr.clear()
             status = "state reloaded"
         elif c == ord("p"):
             curses.endwin()
@@ -1045,7 +1024,9 @@ def cmd_status(sections: list[Section], as_json: bool) -> int:
     refresh_state(sections)
     disabled = sum(1 for sec in sections for it in sec.items if it.disabled)
     total = sum(len(sec.items) for sec in sections)
-    running = find_pids_for_labels([it.label for sec in sections for it in sec.items])
+    running = running_pids([it.label for sec in sections for it in sec.items])
+    ignored = sorted(it.label for sec in sections for it in sec.items
+                     if it.disabled and it.label in running)
     spot = spotlight_state()
     free = mem_free_mb()
     if as_json:
@@ -1054,6 +1035,7 @@ def cmd_status(sections: list[Section], as_json: bool) -> int:
             "disabled": disabled,
             "enabled": total - disabled,
             "running": sorted(running),
+            "disabled_but_running": ignored,
             "spotlight": spot,
             "reclaimable_ram_mb": free,
         }, indent=2))
@@ -1061,6 +1043,9 @@ def cmd_status(sections: list[Section], as_json: bool) -> int:
     print(f"labels present on this macOS: {total}")
     print(f"  disabled: {disabled}   enabled: {total - disabled}")
     print(f"  running now: {len(running)}")
+    if ignored:
+        print(f"  disabled but running anyway: {len(ignored)}   "
+              f"(launchd started these despite the override)")
     print(f"spotlight: {spot}")
     if free is not None:
         print(f"reclaimable RAM now: ~{free} MB")
@@ -1165,7 +1150,7 @@ def cmd_preset(sections: list[Section], name: str, dry_run: bool) -> int:
     return run_apply(sections, dry_run)
 
 
-VERSION = "0.7.1"
+VERSION = "0.7.2"
 
 HELP = f"""mac-os-debloat {VERSION} — toggle non-essential macOS launchd services.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oleksandr_krupko/mac-os-debloat",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Debloat your Mac from the terminal. SIP-safe interactive console util to disable 270 non-essential macOS launchd services + Spotlight toggle, with telemetry/balanced presets and your own custom presets. Self-validates against your macOS build. macOS Tahoe + Apple Silicon. Zero deps.",
   "bin": {
     "mac-os-debloat": "bin/cli.js",

--- a/tests/test_debloat.py
+++ b/tests/test_debloat.py
@@ -7,8 +7,10 @@ SIP-enabled machine from issue #8 without touching the real one.
 """
 from __future__ import annotations
 
+import contextlib
 import importlib.machinery
 import importlib.util
+import io
 import json
 import os
 import stat
@@ -49,8 +51,8 @@ if action == "print":
     print("\t\tcom.apple.SomeBlastDoorService")
     print("\t}")
     print("\tservices = {")
-    for label in d["services"]:
-        print(f"\t\t     0      - \t{label}")
+    for label, pid in d["services"].items():
+        print(f"\t\t     {pid}      - \t{label}")
     print("\t}")
     print("\tdisabled services = {")
     for label in d["disabled"]:
@@ -79,7 +81,7 @@ open(state_path, "w").write(json.dumps(state))
 sys.exit(0)
 '''
 
-FAKE_SUDO = '#!/bin/sh\nexec "$@"\n'
+FAKE_SUDO = '#!/bin/sh\n[ "$1" = "-v" ] && exit 0\nexec "$@"\n'
 
 
 def load_debloat():
@@ -110,8 +112,8 @@ class FakeMachine:
             "overrides_land": True,
             "fail": {},
             "domains": {
-                "system": {"services": [], "disabled": []},
-                self.gui: {"services": [], "disabled": []},
+                "system": {"services": {}, "disabled": []},
+                self.gui: {"services": {}, "disabled": []},
             },
         }
         bindir = tmp / "bin"
@@ -129,13 +131,13 @@ class FakeMachine:
         self.state_path.write_text(json.dumps(self.state))
 
     def add(self, label: str, *, agent_plist=False, daemon_plist=False,
-            registered=(), disabled=()):
+            registered=(), disabled=(), pid=0):
         if agent_plist:
             (self.agents / f"{label}.plist").touch()
         if daemon_plist:
             (self.daemons / f"{label}.plist").touch()
         for domain in registered:
-            self.state["domains"][domain]["services"].append(label)
+            self.state["domains"][domain]["services"][label] = pid
         for domain in disabled:
             self.state["domains"][domain]["disabled"].append(label)
         self.flush()
@@ -156,7 +158,7 @@ class FakeMachine:
         self.state = json.loads(self.state_path.read_text())
 
 
-class DomainTest(unittest.TestCase):
+class FakeMachineTest(unittest.TestCase):
     def setUp(self):
         self.debloat = load_debloat()
         self._path = os.environ["PATH"]
@@ -174,6 +176,14 @@ class DomainTest(unittest.TestCase):
     def items(self, secs):
         return {it.label: it for sec in secs for it in sec.items}
 
+    def capture(self, fn, *args) -> str:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            fn(*args)
+        return out.getvalue()
+
+
+class DomainTest(FakeMachineTest):
     # --- issue #8 part 2: --status unions the domains ---
 
     def test_override_in_a_domain_the_job_does_not_live_in_is_not_disabled(self):
@@ -268,6 +278,125 @@ class DomainTest(unittest.TestCase):
         self.assertEqual(result["not_disabled"], ["com.example.agent"])
 
 
+class RunningPidsTest(FakeMachineTest):
+    def test_labels_sharing_a_last_segment_are_not_confused(self):
+        """`com.apple.spindump` and `com.apple.metadata.mds.spindump` both end in
+        `spindump`. Keying on that segment reported the idle one as running."""
+        self.machine.add("com.example.spindump", daemon_plist=True,
+                         registered=["system"], pid=0)
+        self.machine.add("com.example.metadata.spindump", daemon_plist=True,
+                         registered=["system"], pid=900)
+        pids = self.debloat.running_pids(
+            ["com.example.spindump", "com.example.metadata.spindump"])
+        self.assertEqual(pids, {"com.example.metadata.spindump": [900]})
+
+    def test_a_label_running_in_both_domains_reports_both_pids(self):
+        self.machine.add("com.example.both", agent_plist=True, daemon_plist=True,
+                         registered=["system"], pid=11)
+        self.machine.state["domains"][self.gui]["services"]["com.example.both"] = 22
+        self.machine.flush()
+        self.assertEqual(self.debloat.running_pids(["com.example.both"]),
+                         {"com.example.both": [11, 22]})
+
+
+class StatusTest(FakeMachineTest):
+    def test_status_counts_a_label_that_is_disabled_and_still_running(self):
+        """macOS 26.5.2 starts jobs whose override is in place and in the right
+        domain, so `disabled` alone reads as success while the daemon runs."""
+        self.machine.add("com.example.ignored", daemon_plist=True,
+                         registered=["system"], disabled=["system"], pid=770)
+        self.machine.add("com.example.obeyed", daemon_plist=True,
+                         registered=["system"], disabled=["system"], pid=0)
+        secs, _ = self.sections("com.example.ignored", "com.example.obeyed")
+        out = json.loads(self.capture(self.debloat.cmd_status, secs, True))
+        self.assertEqual(out["disabled"], 2)
+        self.assertEqual(out["disabled_but_running"], ["com.example.ignored"])
+
+
+class CommandLineTest(FakeMachineTest):
+    """The flags end to end, through `main()`, against the fake machine."""
+
+    def setUp(self):
+        super().setUp()
+        self.debloat.BACKUP_DIR = self.machine.tmp / "backup"
+        self.debloat.PRESETS_DIR = self.debloat.BACKUP_DIR / "presets"
+        self.debloat.USER_LABELS_FILE = self.debloat.BACKUP_DIR / "labels.txt"
+        self.debloat.PRESETS_DIR.mkdir(parents=True)
+        self.debloat.spotlight_state = lambda: "off"
+        self.debloat.mem_free_mb = lambda: 4096
+
+    def run_cli(self, *argv) -> tuple[int, str]:
+        original = sys.argv
+        sys.argv = ["debloat", *argv]
+        try:
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+                code = self.debloat.main()
+            return code, out.getvalue()
+        finally:
+            sys.argv = original
+
+    def two_labels(self):
+        self.debloat.EMBEDDED_LABELS = (
+            "# === Telemetry [telemetry] ===\n"
+            "com.example.telemetry  # analytics\n"
+            "# === Photos ===\n"
+            "com.example.photos     # photo analysis\n"
+        )
+        self.machine.add("com.example.telemetry", daemon_plist=True, registered=["system"])
+        self.machine.add("com.example.photos", daemon_plist=True, registered=["system"])
+
+    def test_dry_run_changes_nothing_on_the_system(self):
+        self.two_labels()
+        code, out = self.run_cli("--disable-all", "--dry-run")
+        self.assertEqual(code, 0)
+        self.assertIn("[dry-run] would disable 2", out)
+        self.assertEqual(self.machine.commands(), [])
+
+    def test_preset_does_not_re_enable_a_label_outside_it(self):
+        """`--preset` disables its own labels and leaves the rest as they are;
+        re-enabling something the user had already turned off is data loss."""
+        self.two_labels()
+        self.machine.state["domains"]["system"]["disabled"].append("com.example.photos")
+        self.machine.flush()
+        code, _ = self.run_cli("--preset", "telemetry")
+        self.assertEqual(code, 0)
+        self.assertEqual(self.machine.commands(),
+                         ["disable system/com.example.telemetry",
+                          "bootout system/com.example.telemetry"])
+
+    def test_restore_puts_back_exactly_the_pre_apply_state(self):
+        self.two_labels()
+        self.machine.state["domains"]["system"]["disabled"].append("com.example.photos")
+        self.machine.flush()
+        self.run_cli("--disable-all")
+        self.machine.reread()
+        self.assertEqual(sorted(self.machine.state["domains"]["system"]["disabled"]),
+                         ["com.example.photos", "com.example.telemetry"])
+        self.run_cli("--restore")
+        self.machine.reread()
+        self.assertEqual(self.machine.state["domains"]["system"]["disabled"],
+                         ["com.example.photos"])
+
+    def test_list_output_is_valid_input_for_preset(self):
+        """The README promises the round-trip; it breaks if either the comment
+        column or the section header stops parsing."""
+        self.two_labels()
+        _, listed = self.run_cli("--list")
+        (self.debloat.PRESETS_DIR / "mine.txt").write_text(listed)
+        code, out = self.run_cli("--preset", "mine", "--dry-run")
+        self.assertEqual(code, 0)
+        self.assertIn("preset mine: 2 labels", out)
+
+    def test_user_labels_file_extends_the_catalog(self):
+        self.two_labels()
+        self.debloat.USER_LABELS_FILE.write_text("com.example.extra  # mine\n")
+        self.machine.add("com.example.extra", daemon_plist=True, registered=["system"])
+        code, out = self.run_cli("--disable-all", "--dry-run")
+        self.assertEqual(code, 0)
+        self.assertIn("disable  com.example.extra", out)
+
+
 class DomainStateParseTest(unittest.TestCase):
     """`launchctl print <domain>` output, verbatim shape, with the neighbouring
     blocks that must not leak into either set."""
@@ -304,9 +433,9 @@ system = {
             registered, disabled = debloat.domain_state("system")
         finally:
             subprocess.run = original
-        self.assertEqual(registered, {"com.apple.runningboardd",
-                                      "com.apple.kernelmanager_helper",
-                                      "com.apple.wifiFirmwareLoader"})
+        self.assertEqual(registered, {"com.apple.runningboardd": 441,
+                                      "com.apple.kernelmanager_helper": 0,
+                                      "com.apple.wifiFirmwareLoader": 0})
         self.assertEqual(disabled, {"com.apple.tipsd"})
 
 


### PR DESCRIPTION
## The `running now` number was a guess

`find_pids_for_labels` matched `ps` output to labels two ways: the label's last dot segment against the executable basename, then the whole label as a substring of the command line. On this machine that reported **103** running against launchd's own **81**.

It also collided silently. The lookup was keyed on the last dot segment, so `com.apple.spindump` and `com.apple.metadata.mds.spindump` shared a key and the later one overwrote the earlier — the wrong label reported as running, and the right one invisible to the kill phase.

`launchctl print <domain>` already carries the pid of every registered job in its `services` block, and `domain_state` already parses that block for the registration set:

```
		    9682   (pe) 	com.apple.modelcatalogd
		   10001   (pe) 	com.apple.audioanalyticsd
```

So `domain_state` now returns `{label: pid}` instead of a bare set, and `running_pids` reads from it. Authoritative, no extra subprocess, and the heuristic is deleted — net **−28 lines** of production code.

## What the honest pid exposed

With a pid you can trust, `--status` reports the number that actually matters on macOS 26.x:

```
labels present on this macOS: 268
  disabled: 43   enabled: 225
  running now: 81
  disabled but running anyway: 14   (launchd started these despite the override)
```

Those 14 are disabled in **every** domain they are registered in, and running. On this machine, 8 days into an uptime, seven of them were started by launchd (`ppid 1`) between 14:53 and 16:43 on 18 Aug — while `/var/db/com.apple.xpc.launchd/disabled.plist` had not been written since 21:54 on 17 Aug, and `launchctl print-disabled system` read `"com.apple.ospredictiond" => disabled` throughout.

That is a **second, distinct failure** from the boot-time clearing in [#8](https://github.com/OleksandrKrupko/mac-os-debloat/issues/8): the override is intact, in the right domain, and ignored. Nothing in userspace can fix it — `launchctl disable` is the supported SIP-safe interface and it is what is being ignored — so the tool's job is to make it visible. README's Persistence section now documents both failures.

## Also

- **The TUI's `r` no longer prompts for sudo.** It only calls `refresh_state`, which runs `launchctl print` — the same unprivileged read `--status` does without a password.
- **Tests: 9 → 17.** The fake machine models pids, and the flags now run end to end through `main()`, so a green suite means the CLI contract holds:

| test | guarantee |
|---|---|
| `test_dry_run_changes_nothing_on_the_system` | `--dry-run` issues zero launchctl mutations |
| `test_preset_does_not_re_enable_a_label_outside_it` | a preset never undoes the user's own disables |
| `test_restore_puts_back_exactly_the_pre_apply_state` | `--restore` is exact, not approximate |
| `test_list_output_is_valid_input_for_preset` | the documented `--list` round-trip |
| `test_user_labels_file_extends_the_catalog` | `labels.txt` reaches `--disable-all` |
| `test_labels_sharing_a_last_segment_are_not_confused` | the collision above |
| `test_status_counts_a_label_that_is_disabled_and_still_running` | the macOS 26 reality is reported, not hidden |

`python3 -m unittest discover -s tests` — 17 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)