### PR TITLE
feat: spinner for the Spotlight rebuild, in-place apply progress (0.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All three methods need `python3` — preinstalled with the Xcode Command Line To
 
 The top block is a menu: arrow onto `telemetry`, `balanced`, `Disable all` or `Enable all` and press `enter` to apply it right away. `Disable all` disappears once everything is off, `Enable all` once everything is on, so every row on offer does something.
 
-Everything below the menu is a checkbox: `[✓]` on, `[ ]` off. `space` flips the row under the cursor, `enter` applies whatever is ticked. The bottom line always explains the row under the cursor — what the service does and what you lose with it off. The first checkbox is Spotlight ([below](#spotlight)); everything after it is a launchd service.
+Everything below the menu is a checkbox: `[✓]` on, `[ ]` off, `[▘]` spinning while the system is still settling into the state you asked for. `space` flips the row under the cursor, `enter` applies whatever is ticked. The bottom line always explains the row under the cursor — what the service does and what you lose with it off. The first checkbox is Spotlight ([below](#spotlight)); everything after it is a launchd service.
 
 ## Commands
 
@@ -50,6 +50,8 @@ debloat --dry-run          # with --preset/--disable-all/--enable-all: preview o
 debloat --status --json    # machine-readable status
 ```
 
+An apply is two `sudo launchctl` calls per label per domain, so `--disable-all` runs several hundred of them; it prints a `disabling 137/268 com.apple.…` line in place while it works, on the command line and in the TUI alike. Piped output gets none of that.
+
 `--status`, `--audit`, `--list`, and `--dry-run` need no sudo — reading launchd state is unprivileged. Every apply first snapshots your current state to `~/.mac-os-debloat/latest.json`, so `--restore` always brings you back. If anything feels off, `debloat --enable-all` turns it all back on.
 
 ## Spotlight
@@ -59,6 +61,8 @@ debloat --status --json    # machine-readable status
 Spotlight's indexer (`mds`, `mds_stores`, `mdworker`) opens every new or changed file on the disk, extracts its text and metadata, and writes that into an index. A `yarn install` or a fresh clone hands it thousands of files at once, which is why `mds_stores` spikes to gigabytes right after one. The index only serves Cmd-Space file search, Finder search and Mail/Notes search — and launchers like Alfred and Raycast that read it.
 
 The Spotlight checkbox turns it off and on. **Off** runs `mdutil -a -d`: indexing and search stop on every volume, the daemons go idle, and `find`, `grep`, `fd`, `ripgrep`, git and VS Code's search (its own bundled ripgrep) keep working exactly as before. **On** runs `mdutil -a -i on` plus `mdutil -a -E`, a full rebuild that costs 10-30 minutes of CPU. Off is the right setting if you search from your editor or the shell and never from Cmd-Space. `--restore` puts Spotlight back the way it was before your last apply, too.
+
+Turning it **on** is not instant: `mdutil -a -E` wipes the store and the rebuild runs for 10-30 minutes. During that window `mdutil` reports neither on nor off, so the row shows a spinner instead of a checkbox and the bottom line says what is happening. The TUI re-checks every 3 seconds and the row settles to `[✓]` on its own — you can keep working, or quit; quitting does not stop the rebuild. Tick the row and press `enter` during the rebuild and your pending `*` takes the spinner's place, so a change you asked for is never hidden by it.
 
 `--status` reports `spotlight: on`, `off`, or `indexing` (rebuild in progress).
 
@@ -146,7 +150,7 @@ Full curated list with per-label comments lives inside the script (`EMBEDDED_LAB
 | `r` | reload state from system |
 | `q` / `esc` | quit |
 
-`[✓]` = on · `[ ]` = off · ` *` = changes on enter. The Spotlight row is toggled and applied like any other. The preset menu rows carry no checkbox — `space` does nothing on them, `enter` runs them. `Disable all` asks for confirmation first.
+`[✓]` = on · `[ ]` = off · `[▘]` = the system is still settling into the state you asked for · ` *` = changes on enter. The Spotlight row is toggled and applied like any other. The preset menu rows carry no checkbox — `space` does nothing on them, `enter` runs them. `Disable all` asks for confirmation first.
 
 </details>
 

--- a/debloat
+++ b/debloat
@@ -6,7 +6,8 @@ on Enter.
 
 The top rows are a preset menu — enter on one applies it right away. Below
 that the Spotlight file index, then every launchd service. `[✓]` means on,
-`[ ]` means off, `*` marks a row that changes on enter.
+`[ ]` means off, `*` marks a row that changes on enter, and a spinner marks
+a row the system has not finished settling into (Spotlight rebuilding).
 
 Keys:
   ↑/↓ or j/k   move
@@ -476,6 +477,7 @@ class Item:
     selected: bool = False
     domains: set[str] = field(default_factory=set)
     action: str = ""
+    state: str = ""
 
 
 @dataclass
@@ -621,6 +623,18 @@ def pending_changes(sections: list[Section]) -> tuple[list[str], list[str]]:
     return to_disable, to_enable
 
 
+def progress(text: str) -> None:
+    """Overwrite one line in place. An apply is two sudo `launchctl` runs per
+    label per domain, so `--disable-all` sits silent for hundreds of them
+    otherwise. Skipped off a tty so piped output never gets \\r spam."""
+    if not sys.stdout.isatty():
+        return
+    # Wrapping would leave every frame on screen instead of overwriting one line.
+    w = min(78, os.get_terminal_size().columns - 1)
+    sys.stdout.write("\r" + text[:w].ljust(w) + "\r")
+    sys.stdout.flush()
+
+
 def apply_changes(sections: list[Section]) -> dict:
     to_disable, to_enable = pending_changes(sections)
     domains_of = {it.label: it.domains for sec in sections for it in sec.items}
@@ -641,19 +655,25 @@ def apply_changes(sections: list[Section]) -> dict:
 
     # Phase 1: launchctl disable + bootout (or enable), only in the domains the
     # job is registered in — an override written elsewhere never takes effect.
-    for label in to_disable:
+    total = len(to_disable) + len(to_enable)
+    width = len(str(total))
+    for n, label in enumerate(to_disable, 1):
+        progress(f"  disabling  {n:>{width}}/{total}  {label}")
         for domain in sorted(domains_of[label]):
             launchctl("disable", domain, label)
             launchctl("bootout", domain, label)
-    for label in to_enable:
+    for n, label in enumerate(to_enable, len(to_disable) + 1):
+        progress(f"  enabling   {n:>{width}}/{total}  {label}")
         for domain in sorted(domains_of[label]):
             launchctl("enable", domain, label)
 
     # Phase 2: nuclear kill -9 for anything still running after bootout
     killed = 0
     if to_disable:
+        progress("  looking for survivors...")
         survivors = running_pids(to_disable)
         for label, pids in survivors.items():
+            progress(f"  killing    {label}")
             for pid in pids:
                 r = subprocess.run(["sudo", "kill", "-9", str(pid)],
                                    capture_output=True, check=False)
@@ -661,12 +681,14 @@ def apply_changes(sections: list[Section]) -> dict:
                     killed += 1
 
     # Phase 3: brief settle then verify nothing respawned
+    progress("  verifying...")
     time.sleep(0.4)
     stragglers: dict[str, list[int]] = {}
     if to_disable:
         stragglers = running_pids(to_disable)
 
     disabled_now = {d: domain_state(d)[1] for d in DOMAINS}
+    progress("")
     return {
         "disabled": len(to_disable),
         "enabled": len(to_enable),
@@ -737,6 +759,9 @@ SPOTLIGHT_SECTION = "Spotlight file index"
 SPOTLIGHT_COMMENT = ("reads every new or changed file to power Cmd-Space and Finder search. "
                      "Off: no background indexing, RAM and CPU back; VS Code, grep, fd, git "
                      "unaffected. Lost: Cmd-Space file search, Finder search, Mail search")
+SPOTLIGHT_INDEXING = ("rebuilding the index — this runs for 10-30 minutes of CPU. Cmd-Space "
+                      "and Finder search stay incomplete until it lands; nothing to do but "
+                      "wait, and quitting here does not stop it")
 
 
 def spotlight_section() -> Section:
@@ -748,27 +773,33 @@ def spotlight_section() -> Section:
 
 def refresh_spotlight(section: Section) -> None:
     item = section.items[0]
-    item.disabled = spotlight_state() == "off"
+    item.state = spotlight_state()
+    item.disabled = item.state == "off"
     item.selected = not item.disabled
+    item.comment = SPOTLIGHT_INDEXING if item.state == "indexing" else SPOTLIGHT_COMMENT
 
 
 def spotlight_set(enabled: bool) -> tuple[bool, str]:
+    progress(f"  turning Spotlight {'on' if enabled else 'off'}...")
     if not enabled:
         # `-i off` leaves the Data volume's indexer running on macOS 26; `-d`
         # stops indexing and searching on every volume.
         r = subprocess.run(["sudo", "mdutil", "-a", "-d"],
                            capture_output=True, text=True, check=False)
+        progress("")
         if r.returncode != 0:
             return False, f"mdutil failed: {r.stderr.strip()}"
         return True, "Spotlight off — indexing and search stopped"
     r = subprocess.run(["sudo", "mdutil", "-a", "-i", "on"],
                        capture_output=True, text=True, check=False)
     if r.returncode != 0:
+        progress("")
         return False, f"mdutil failed: {r.stderr.strip()}"
     # `-i on` only sets the flag; a previously disabled index stays in an
     # "unknown" state and never rebuilds, so Finder metadata queries hang.
     e = subprocess.run(["sudo", "mdutil", "-a", "-E"],
                        capture_output=True, text=True, check=False)
+    progress("")
     if e.returncode != 0:
         return False, f"mdutil -E failed: {e.stderr.strip()}"
     return True, "Spotlight on — full reindex running (~10-30 min of CPU)"
@@ -867,7 +898,13 @@ def build_display_rows(sections: list[Section]) -> tuple[list[tuple[str, object]
     return rows, item_to_row
 
 
-def draw(stdscr, sections: list[Section], cursor: int, status: str, scroll: list[int]) -> None:
+SPINNER = "▖▘▝▗"
+SPINNER_MS = 140
+SPOTLIGHT_POLL_S = 3
+
+
+def draw(stdscr, sections: list[Section], cursor: int, status: str, scroll: list[int],
+         tick: int = 0) -> None:
     stdscr.erase()
     h, w = stdscr.getmaxyx()
     title = ("mac-os-debloat   ↑↓ move   space toggle   [ ] section   "
@@ -908,6 +945,10 @@ def draw(stdscr, sections: list[Section], cursor: int, status: str, scroll: list
             it = payload  # type: ignore[assignment]
             if it.action:
                 text = f"   ▸   {it.label:<48}  {it.comment}"
+            elif it.state == "indexing" and it.selected != it.disabled:
+                # A ticked change outranks the spinner: the user must still see
+                # the `*` and the box they asked for while the rebuild runs.
+                text = f"  [{SPINNER[tick % len(SPINNER)]}]  {it.label:<48}  {it.comment}"
             else:
                 mark = "[✓]" if it.selected else "[ ]"
                 changed = " *" if it.selected == it.disabled else "  "
@@ -946,13 +987,27 @@ def run_tui(stdscr, sections: list[Section]) -> str | None:
     status = ""
     scroll = [0]
     spotlight = spotlight_section()
+    tick = 0
+    polled_at = 0.0
     while True:
         view = [menu_section(sections), spotlight, *sections]
         flat = flat_index(view)
         cursor = max(0, min(cursor, len(flat) - 1))
-        draw(stdscr, view, cursor, status, scroll)
-        status = ""
+        # Only run getch on a timer while the spinner has something to say —
+        # a permanent timeout would put us back in the issue #1 busy-loop, and
+        # the poll is rate-limited separately so the animation never costs an
+        # `mdutil` per frame.
+        is_spinning = spotlight.items[0].state == "indexing"
+        stdscr.timeout(SPINNER_MS if is_spinning else -1)
+        draw(stdscr, view, cursor, status, scroll, tick)
         c = stdscr.getch()
+        if c == -1:
+            tick += 1
+            if time.time() - polled_at > SPOTLIGHT_POLL_S:
+                refresh_spotlight(spotlight)
+                polled_at = time.time()
+            continue
+        status = ""
         if c in (ord("q"), 27):
             return None
         if c in (curses.KEY_DOWN, ord("j")):
@@ -984,6 +1039,7 @@ def run_tui(stdscr, sections: list[Section]) -> str | None:
                 stdscr.clrtoeol()
                 stdscr.addnstr(h - 1, 0, ask[:w - 1], w - 1, curses.A_REVERSE)
                 stdscr.refresh()
+                stdscr.timeout(-1)
                 if stdscr.getch() not in (ord("y"), ord("Y")):
                     status = "disable all cancelled"
                     continue
@@ -1216,7 +1272,7 @@ def cmd_preset(sections: list[Section], name: str, dry_run: bool) -> int:
     return run_apply(sections, dry_run)
 
 
-VERSION = "0.9.0"
+VERSION = "0.10.0"
 
 HELP = f"""mac-os-debloat {VERSION} — toggle non-essential macOS launchd services and the Spotlight index.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oleksandr_krupko/mac-os-debloat",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Debloat your Mac from the terminal. SIP-safe interactive console util to disable 270 non-essential macOS launchd services + Spotlight toggle, with one-key telemetry/balanced presets in the TUI and your own custom presets. Self-validates against your macOS build. macOS Tahoe + Apple Silicon. Zero deps.",
   "bin": {
     "mac-os-debloat": "bin/cli.js",

--- a/tests/test_debloat.py
+++ b/tests/test_debloat.py
@@ -496,6 +496,46 @@ class SpotlightStateTest(FakeMachineTest):
         self.assertEqual(self.debloat.spotlight_state(), "indexing")
 
 
+class SpotlightRowTest(FakeMachineTest):
+    def test_rebuilding_index_is_a_third_row_state_not_a_ticked_box(self):
+        """The row is tri-state: collapsing it back to `disabled` bool alone
+        loses the rebuild, and the row reads as plainly on while mds churns."""
+        section = self.debloat.spotlight_section()
+        item = section.items[0]
+        self.assertEqual(item.state, "on")
+        self.assertEqual(item.comment, self.debloat.SPOTLIGHT_COMMENT)
+
+        self.machine.state["spotlight"]["/"] = "Error: unknown indexing state."
+        self.machine.flush()
+        self.debloat.refresh_spotlight(section)
+        self.assertEqual(item.state, "indexing")
+        self.assertFalse(item.disabled)
+        self.assertEqual(item.comment, self.debloat.SPOTLIGHT_INDEXING)
+
+
+class ProgressTest(unittest.TestCase):
+    def test_nothing_is_written_when_stdout_is_not_a_terminal(self):
+        """The in-place line is \\r padding; letting it reach a pipe fills a
+        scripted `--disable-all` log with control characters."""
+        debloat = load_debloat()
+        piped = io.StringIO()
+        with contextlib.redirect_stdout(piped):
+            debloat.progress("  disabling  1/9  com.example.thing")
+        self.assertEqual(piped.getvalue(), "")
+
+        tty = io.StringIO()
+        tty.isatty = lambda: True
+        original = os.get_terminal_size
+        os.get_terminal_size = lambda *a: os.terminal_size((120, 40))
+        try:
+            with contextlib.redirect_stdout(tty):
+                debloat.progress("  disabling  1/9  com.example.thing")
+        finally:
+            os.get_terminal_size = original
+        self.assertEqual(tty.getvalue(),
+                         "\r" + "  disabling  1/9  com.example.thing".ljust(78) + "\r")
+
+
 class DomainStateParseTest(unittest.TestCase):
     """`launchctl print <domain>` output, verbatim shape, with the neighbouring
     blocks that must not leak into either set."""


### PR DESCRIPTION
## The Spotlight row was lying during a rebuild

Turning Spotlight on runs `mdutil -a -E`, which wipes the store and rebuilds for 10-30 minutes. `mdutil -s` reports neither `on` nor `off` in that window — and the row collapsed that third state to a plain unticked box, so a rebuild in progress looked exactly like a toggle that had not worked.

The row is now the tri-state `mdutil` actually reports:

```
── Spotlight file index ──────────────────────────────────────────────────
  [▘]  Spotlight    rebuilding the index — this runs for 10-30 minutes of CPU. Cmd-
```

- Spinner instead of a checkbox while the index rebuilds, cycling `▖▘▝▗`.
- The bottom detail line swaps to explain what is running, and that **quitting does not stop it**.
- The TUI re-polls every 3s and the row settles to `[✓]` on its own.
- A change the user ticks **outranks** the spinner — tick the row mid-rebuild and you get ` *[ ]` back, so a pending change is never hidden.

`getch` only runs on a timer while there is something to animate, and the poll is rate-limited separately, so the animation never costs an `mdutil` per frame. That is the [#1](https://github.com/OleksandrKrupko/mac-os-debloat/issues/1) busy-loop and it stays fixed — measured 6 `mdutil` calls in 13s of a 140ms animation (~93 frames).

## Applies stopped being silent

An apply is two `sudo launchctl` runs per label per domain, so `--disable-all` was several hundred subprocesses with no output at all. It now overwrites one line in place:

```
  disabling  137/268  com.apple.parsecd
  looking for survivors...
  verifying...
```

Same in the TUI and on the command line, plus the `mdutil` call when Spotlight changes. Off a tty nothing is written, so piped and scripted output is byte-for-byte unchanged.

## Where I did *not* add a loader

Measured on this machine rather than guessed: startup (parse 270 labels, glob 6 plist dirs, both `launchctl print` calls) is **73ms**, each `launchctl print` is **~6ms**, `mdutil -s` is **9ms**. Nothing there is slow enough that a spinner would be anything but noise, so `r` reload and startup are untouched.

## Verification

- `python3 -m unittest discover -s tests` — 25 pass (23 before; 2 new: the row keeps the third state and swaps its explanation, and `progress` writes nothing off a tty).
- Spinner driven in a real pty with a fake `mdutil` pinned to the indexing state, so the user's own Spotlight was never touched: frames advance `▘▝▖▘▝▖`, comment swaps, `space` mid-rebuild gives ` *[ ]` and `pending: 1`.
- Poll rate: 6 `mdutil` calls over ~13s, gaps 3.02-3.08s. CPU: 2.1% while spinning vs 1.5% idle over 10s.
- Every key re-checked while the spinner runs (arrows in application-cursor mode, PgUp/PgDn, `[`/`]`): all navigate, none quit.
- Apply progress captured through a pty at 100 and 40 columns — overwrites one line, never wraps, clears before `applied: …`.
- All eight TUI action paths from 0.9.0 re-run green; `--version`, `--status`, `--preset --dry-run` checked via `python3 debloat` and `node bin/cli.js`.

`screenshot.png` is unchanged — regenerated and pixel-identical, since the default look only differs while a rebuild is running.

**Not verified against a live rebuild:** doing so means a real 10-30 minute reindex on this machine, whose Spotlight is deliberately off. The `indexing` reading is the one the existing `spotlight_state()` and its test already encode; I drove the TUI against that state with a fake `mdutil` rather than trigger the real thing.

https://claude.ai/code/session_01DE3D8qVQaUk2wwfV1Q9q27